### PR TITLE
Add automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+group: travis_latest
+language: python
+python:
+    - 2.7
+    - 3.6
+install:
+    - pip install flake8
+script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Let’s have the Travis Continuous Integration service automatically run [flake8](http://flake8.readthedocs.io) tests on every pull request. This **free** service will find Python syntax errors and undefined names.

To turn on Travis-CI, you would need to do steps 1 and 2 of https://docs.travis-ci.com/user/getting-started